### PR TITLE
Finish off global database

### DIFF
--- a/global_schema.ddl
+++ b/global_schema.ddl
@@ -97,21 +97,9 @@ CREATE TABLE IF NOT EXISTS api_host_port (
 	scope			TEXT,
 	port			INT,
 	space_id		TEXT, -- TODO: Investigate this field
+	agent_useable	BOOL,
 	controller_uuid	TEXT NOT NULL,
 	CONSTRAINT		fk_api_host_port_controller
-		FOREIGN KEY	(controller_uuid)
-		REFERENCES	controller(uuid)
-);
-
-CREATE TABLE IF NOT EXISTS api_host_port_for_agents (
-	uuid			TEXT PRIMARY KEY,
-	value			TEXT,
-	address_type	TEXT,
-	scope			TEXT,
-	port			INT,
-	space_id		TEXT, -- TODO: Investigate this field
-	controller_uuid	TEXT NOT NULL,
-	CONSTRAINT		fk_api_host_port_for_agents_controller
 		FOREIGN KEY	(controller_uuid)
 		REFERENCES	controller(uuid)
 );
@@ -128,50 +116,159 @@ CREATE TABLE IF NOT EXISTS controller_node (
 		REFERENCES	controller(uuid)
 );
 
+CREATE TABLE IF NOT EXISTS state_serving_info (
+	uuid			TEXT PRIMARY KEY,
+	controller_uuid	TEXT NOT NULL,
+	api_port		INT,
+	state_port		INT,
+	cert			TEXT,
+	private_key		TEXT,
+	ca_private_key	TEXT,
+	shared_secret	TEXT,
+	system_identity	TEXT,
+	CONSTRAINT		fk_state_serving_info_controller
+		FOREIGN KEY	(controller_uuid)
+		REFERENCES	controller(uuid)
+);
+
+/*
+ * External Controllers
+ */
+CREATE TABLE IF NOT EXISTS external_controller (
+	uuid			TEXT PRIMARY KEY,
+	alias			TEXT,
+	ca_cert_uuid	TEXT,
+	CONSTRAINT		fk_external_controller_controller
+		FOREIGN KEY	(uuid)
+		REFERENCES	controller(uuid)
+);
+
+CREATE TABLE IF NOT EXISTS external_controller_address (
+	uuid						TEXT PRIMARY KEY,
+	address						TEXT,
+	external_controller_uuid	TEXT NOT NULL,
+	CONSTRAINT					fk_external_controller_address_external_controller
+		FOREIGN KEY				(external_controller_uuid)
+		REFERENCES				external_controller(uuid)
+);
+
 /*
  * Upgrade Info
  */
-CREATE TABLE IF NOT EXISTS upgrade_info (
-	uuid				TEXT PRIMARY KEY,
-	id					TEXT NOT NULL,
-	previous_version	TEXT,
-	target_version		TEXT,
-	status				TEXT,
-	started				TIMESTAMP
+CREATE TABLE IF NOT EXISTS upgrade_status (
+	id		INT PRIMARY KEY,
+	status	TEXT
 );
 
-CREATE UNIQUE INDEX IF NOT EXISTS idx_upgrade_info_id
-ON upgrade_info (id);
+INSERT INTO upgrade_status VALUES
+(
+	0,
+	"pending"
+), (
+	1,
+	"db-complete"
+), (
+	2,
+	"running"
+), (
+	3,
+	"complete"
+), (
+	4,
+	"aborted"
+);
+
+CREATE TABLE IF NOT EXISTS upgrade_info (
+	uuid				TEXT PRIMARY KEY,
+	controller_uuid		TEXT NOT NULL,
+	previous_version	TEXT,
+	target_version		TEXT,
+	status_id			INT NOT NULL,
+	started				TIMESTAMP,
+	CONSTRAINT			fk_upgrade_info_controller
+		FOREIGN KEY		(controller_uuid)
+		REFERENCES		controller(uuid),
+	CONSTRAINT			fk_upgrade_info_status
+		FOREIGN KEY		(status_id)
+		REFERENCES		upgrade_status(id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_upgrade_info_cid
+ON upgrade_info (controller_uuid);
 
 CREATE TABLE IF NOT EXISTS controller_node_upgrade_ready (
 	uuid					TEXT PRIMARY KEY,
 	controller_node_uuid	TEXT NOT NULL,
-	upgrade_info_id			TEXT NOT NULL,
+	upgrade_info_uuid		TEXT NOT NULL,
 	CONSTRAINT				fk_upgrade_ready_controller
 		FOREIGN KEY			(controller_node_uuid)
 		REFERENCES			controller_node(uuid),
 	CONSTRAINT				fk_upgrade_ready_upgrade_info
-		FOREIGN KEY			(upgrade_info_id)
-		REFERENCES			upgrade_info(id)
+		FOREIGN KEY			(upgrade_info_uuid)
+		REFERENCES			upgrade_info(uuid)
 );
 
 CREATE UNIQUE INDEX IF NOT EXISTS idx_controller_node_upgrade_ready_cnid_uiid
-ON controller_node_upgrade_ready (controller_node_uuid, upgrade_info_id);
+ON controller_node_upgrade_ready (controller_node_uuid, upgrade_info_uuid);
 
 CREATE TABLE IF NOT EXISTS controller_node_upgrade_done (
 	uuid					TEXT PRIMARY KEY,
 	controller_node_uuid	TEXT NOT NULL,
-	upgrade_info_id			TEXT NOT NULL,
+	upgrade_info_uuid		TEXT NOT NULL,
 	CONSTRAINT				fk_upgrade_done_controller
 		FOREIGN KEY			(controller_node_uuid)
 		REFERENCES			controller_node(uuid),
 	CONSTRAINT				fk_upgrade_done_upgrade_info
-		FOREIGN KEY			(upgrade_info_id)
-		REFERENCES			upgrade_info(id)
+		FOREIGN KEY			(upgrade_info_uuid)
+		REFERENCES			upgrade_info(uuid)
 );
 
 CREATE UNIQUE INDEX IF NOT EXISTS idx_controller_node_upgrade_done_cnid_uiid
-ON controller_node_upgrade_done (controller_node_uuid, upgrade_info_id);
+ON controller_node_upgrade_done (controller_node_uuid, upgrade_info_uuid);
+
+/*
+ * Restore Info
+ */
+CREATE TABLE IF NOT EXISTS restore_status (
+	id		INT PRIMARY KEY,
+	status	TEXT
+);
+
+INSERT INTO restore_status VALUES
+(
+	0,
+	"NOT-RESTORING"
+), (
+	1,
+	"PENDING"
+), (
+	2,
+	"RESTORING"
+), (
+	3,
+	"RESTORED"
+), (
+	4,
+	"CHECKED"
+), (
+	5,
+	"FAILED"
+);
+
+CREATE TABLE IF NOT EXISTS restore_info (
+	uuid			TEXT PRIMARY KEY,
+	controller_uuid	TEXT NOT NULL,
+	status_id		INT NOT NULL,
+	CONSTRAINT			fk_restore_info_controller
+		FOREIGN KEY		(controller_uuid)
+		REFERENCES		controller(uuid)
+	CONSTRAINT			fk_restore_info_status
+		FOREIGN KEY		(status_id)
+		REFERENCES		restore_status(id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_restore_info_cid
+ON restore_info (controller_uuid);
 
 /*
  * Users
@@ -188,7 +285,7 @@ CREATE TABLE IF NOT EXISTS user (
 	created_by_user_uuid	TEXT,
 	date_created			TIMESTAMP,
 	last_login				TIMESTAMP,
-	last_login_model_uuid	TEXT, -- Not constrained to avoid circulate reference
+	last_login_model_uuid	TEXT, -- Not constrained to avoid circular reference
 	CONSTRAINT				fk_user_created_by_user
 		FOREIGN KEY			(created_by_user_uuid)
 		REFERENCES			user(uuid)
@@ -211,6 +308,57 @@ CREATE TABLE IF NOT EXISTS user_controller_access (
 
 CREATE UNIQUE INDEX IF NOT EXISTS idx_user_controller_access_uid_cid
 ON user_controller_access (user_uuid, controller_uuid);
+
+/*
+ * User Permissions
+ */
+CREATE TABLE IF NOT EXISTS access_type (
+	id			INT PRIMARY KEY,
+	access_type		TEXT
+);
+
+INSERT INTO access_type VALUES
+(
+	0,
+	""
+), (
+	1,
+	"read"
+), (
+	2,
+	"write"
+), (
+	3,
+	"consume"
+), (
+	4,
+	"admin"
+), (
+	5,
+	"login"
+), (
+	6,
+	"add-model"
+), (
+	7,
+	"superuser"
+);
+
+CREATE TABLE IF NOT EXISTS permission (
+	uuid				TEXT PRIMARY KEY,
+	model_uuid			TEXT NOT NULL,
+	user_uuid			TEXT NOT NULL,
+	access_type_id			INT NOT NULL,
+	CONSTRAINT			fk_permission_model
+		FOREIGN KEY		(model_uuid)
+		REFERENCES		model(uuid),
+	CONSTRAINT			fk_permission_user
+		FOREIGN KEY		(user_uuid)
+		REFERENCES		user(uuid),
+	CONSTRAINT			fk_permission_access_type
+		FOREIGN KEY		(access_type_id)
+		REFERENCES		access_type(id)
+);
 
 /*
  * Cloud Credentials
@@ -269,43 +417,47 @@ INSERT INTO sla VALUES
 );
 
 CREATE TABLE IF NOT EXISTS model (
-	uuid					TEXT PRIMARY KEY,
-	name					TEXT,
-	type					TEXT,
-	life					INT,
-	owner_uuid				TEXT NOT NULL,
-	controller_uuid			TEXT NOT NULL,
-	migration_mode			TEXT,
-	environ_version			INT,
-	cloud_uuid				TEXT NOT NULL,
-	cloud_region_uuid		TEXT,
-	cloud_credential_uuid	TEXT,
-	latest_available_tools	TEXT,
-	sla_id					INT,
-	meter_status			TEXT,
-	meter_info				TEXT,
-	password_hash			TEXT,
-	force_destroyed			BOOLEAN,
-	destroy_timeout			INT,
-	controller_model		BOOLEAN,
-	CONSTRAINT				fk_model_owner
-		FOREIGN KEY			(owner_uuid)
-		REFERENCES			user(uuid),
-	CONSTRAINT				fk_model_controller
-		FOREIGN KEY			(controller_uuid)
-		REFERENCES			controller(uuid),
-	CONSTRAINT				fk_model_cloud
-		FOREIGN KEY			(cloud_uuid)
-		REFERENCES			cloud(uuid),
-	CONSTRAINT				fk_model_cloud_region
-		FOREIGN KEY			(cloud_region_uuid)
-		REFERENCES			cloud_region(uuid),
-	CONSTRAINT				fk_model_cloud_credential
-		FOREIGN KEY			(cloud_credential_uuid)
-		REFERENCES			cloud_credential(uuid),
-	CONSTRAINT				fk_model_sla
-		FOREIGN KEY			(sla_id)
-		REFERENCES			sla(id)
+	uuid						TEXT PRIMARY KEY,
+	name						TEXT,
+	type						TEXT,
+	life						INT,
+	owner_uuid					TEXT NOT NULL,
+	controller_uuid				TEXT NOT NULL,
+	external_controller_uuid	TEXT,
+	migration_mode				TEXT,
+	environ_version				INT,
+	cloud_uuid					TEXT NOT NULL,
+	cloud_region_uuid			TEXT,
+	cloud_credential_uuid		TEXT,
+	latest_available_tools		TEXT,
+	sla_id						INT,
+	meter_status				TEXT,
+	meter_info					TEXT,
+	password_hash				TEXT,
+	force_destroyed				BOOLEAN,
+	destroy_timeout				INT,
+	controller_model			BOOLEAN,
+	CONSTRAINT					fk_model_owner
+		FOREIGN KEY				(owner_uuid)
+		REFERENCES				user(uuid),
+	CONSTRAINT					fk_model_controller
+		FOREIGN KEY				(controller_uuid)
+		REFERENCES				controller(uuid),
+	CONSTRAINT					fk_model_external_controller
+		FOREIGN KEY				(external_controller_uuid)
+		REFERENCES				external_controller(uuid)
+	CONSTRAINT					fk_model_cloud
+		FOREIGN KEY				(cloud_uuid)
+		REFERENCES				cloud(uuid),
+	CONSTRAINT					fk_model_cloud_region
+		FOREIGN KEY				(cloud_region_uuid)
+		REFERENCES				cloud_region(uuid),
+	CONSTRAINT					fk_model_cloud_credential
+		FOREIGN KEY				(cloud_credential_uuid)
+		REFERENCES				cloud_credential(uuid),
+	CONSTRAINT					fk_model_sla
+		FOREIGN KEY				(sla_id)
+		REFERENCES				sla(id)
 );
 
 -- This unique index exists to ensure that two models,
@@ -359,16 +511,104 @@ CREATE TABLE IF NOT EXISTS migration_minion_sync (
 );
 
 /*
- * Global Settings
+ * Metrics
  */
-CREATE TABLE IF NOT EXISTS global_setting (
+CREATE TABLE IF NOT EXISTS metrics_batch (
 	uuid			TEXT PRIMARY KEY,
-	name			TEXT NOT NULL,
-	value			TEXT
+	model_uuid		TEXT NOT NULL,
+	unit			TEXT,
+	charm_url		TEXT,
+	sent			BOOLEAN,
+	delete_time		TIMESTAMP,
+	created			TIMESTAMP,
+	credentials		TEXT,
+	sla_credential	TEXT,
+	CONSTRAINT		fk_metrics_batch_model
+		FOREIGN KEY	(model_uuid)
+		REFERENCES	model(uuid)
 );
 
-CREATE UNIQUE INDEX IF NOT EXISTS idx_global_setting_name
-ON global_setting (name);
+CREATE TABLE IF NOT EXISTS metric (
+	uuid				TEXT PRIMARY KEY,
+	metrics_batch_uuid	TEXT NOT NULL,
+	key					TEXT,
+	value				TEXT,
+	time				TIMESTAMP,
+	CONSTRAINT			fk_metric_metric_batch
+		FOREIGN KEY		(metrics_batch_uuid)
+		REFERENCES		metrics_batch(uuid)
+);
+
+CREATE TABLE IF NOT EXISTS metric_label (
+	uuid			TEXT PRIMARY KEY,
+	metric_uuid		TEXT NOT NULL,
+	key				TEXT,
+	value			TEXT,
+	CONSTRAINT		fk_metric_label_metric
+		FOREIGN KEY	(metric_uuid)
+		REFERENCES	metric(uuid)
+);
+
+CREATE TABLE IF NOT EXISTS metric_manager (
+	uuid					TEXT PRIMARY KEY,
+	last_successful_send	TIMESTAMP,
+	consecutive_errors		INT,
+	grace_period			INT
+);
+
+/*
+ * Leases
+ */
+CREATE TABLE IF NOT EXISTS lease_type (
+	id		INT PRIMARY KEY,
+	type	TEXT
+);
+
+INSERT INTO lease_type VALUES
+(
+	0,
+	"controller"
+), (
+	1,
+	"model"
+), (
+	2,
+	"application"
+);
+
+CREATE TABLE IF NOT EXISTS lease (
+	uuid			TEXT PRIMARY KEY,
+	lease_type_id	INT NOT NULL,
+	name			TEXT,
+	holder			TEXT,
+	start			TIMESTAMP,
+	duration		INT,
+	pinned			BOOLEAN,
+	CONSTRAINT		fk_lease_lease_type
+		FOREIGN KEY	(lease_type_id)
+		REFERENCES	lease_type(id)
+);
+
+/*
+ * Settings
+ */
+CREATE TABLE IF NOT EXISTS settings_group (
+	uuid			TEXT PRIMARY KEY,
+	group_name		TEXT
+);
+
+CREATE TABLE IF NOT EXISTS settings_value (
+	uuid				TEXT PRIMARY KEY,
+	settings_group_uuid	TEXT NOT NULL,
+	key					TEXT,
+	value				TEXT,
+	CONSTRAINT			fk_setting_settings_group
+		FOREIGN KEY		(settings_group_uuid)
+		REFERENCES		settings_group(uuid)
+);
+
+CREATE INDEX IF NOT EXISTS idx_setting_sbid
+ON settings_value (settings_group_uuid);
 
 /*
  * Autocert Cache
@@ -376,25 +616,4 @@ ON global_setting (name);
 CREATE TABLE IF NOT EXISTS autocert_cache (
 	uuid			TEXT PRIMARY KEY,
 	name			TEXT
-);
-
-/*
- * Singletons
- */
--- This table will have only 1 row
-CREATE TABLE IF NOT EXISTS state_serving_info (
-	id				INT PRIMARY KEY,
-	api_port		INT,
-	state_port		INT,
-	cert			TEXT,
-	private_key		TEXT,
-	ca_private_key	TEXT,
-	shared_secret	TEXT,
-	system_identity	TEXT
-);
-
--- This table will have only 1 row
-CREATE TABLE IF NOT EXISTS hosted_model_count (
-	id				INT PRIMARY KEY,
-	ref_count		INT
 );


### PR DESCRIPTION
Add remaining collections to global database schema

Also make a few minor adjustments/improvements

Here is a list of the global collections that need to be replicated in this ddl:
```
controllersC
controllerNodesC
restoreInfoC
upgradeInfoC
modelsC
migrationsC
migrationsStatusC
migrationsActiveC
migrationsMinionSyncC
usersC
controllerUsersC
userLastLoginC
usermodelnameC
cloudsC
cloudCredentialsC
globalSettingsC
metricsC
metricsManagerC
bakeryStorageItemsC
permissionsC
autocertCacheC
externalControllersC
```

#### controllerC
covered by controller, api_host_port, api_host_port_for_agents, state_serving_info, hosted_model_count

#### controllerNodesC
covered by controller_node

#### restoreInfoC
covered by restore_status, restore_info

#### UpgradeInfoC
covered by upgrade_info, controller_node_upgrade_ready, controller_node_upgrade_done

#### modelsC
covered by model

#### migrationsC
covered by migration

#### migrationsStatusC
covered by migration

#### migrationsActive
covered by migration

#### migrationsMinionSyncC
covered by migration_minion_sync

#### usersC
covered by user

#### controllerUsersC
covered by user_controller_access

#### userLastLoginC
covered by user

#### usermodelnameC
covered by idx_model_name_oid (see comment)

#### cloudsC
covered by cloud, cloud_region, auth_type, cloud_auth_type, ca_cert, cloud_ca_cert

#### cloudCredentialsC
covered by cloud_credential and cloud_credential_attribute

#### globalSettingsC
covered by settings_batch, setting

#### metricsC
covered by metrics_batch, metric and metric_label

#### metricsManagerC
covered by metric_manager

#### bakeryStorageItemsC
covered by settings_batch, setting

#### permissionC
covered by permission

#### autocertCacheC
covered by autocert_cache

#### externalControllersC
covered by external_controller and external_controller_address